### PR TITLE
Font hinting

### DIFF
--- a/etc/X11/Xresources/x11-common
+++ b/etc/X11/Xresources/x11-common
@@ -8,3 +8,16 @@
 ! make Xaw (Athena widget set) clients understand the delete key
 ! this causes problems with some non-Xaw apps, use with care
 ! *Text.translations: #override ~Shift ~Meta <Key>Delete: delete-next-character()
+
+
+
+! You can define basic font resources without the need of a fonts.conf file
+! or a desktop environment. Note however, the use of a desktop environment
+! and/or fonts.conf can override these settings.
+
+Xft.antialias: 1
+Xft.hinting: 1
+Xft.autohint: 0
+Xft.hintstyle: hintslight
+Xft.rgba: rgb
+Xft.lcdfilter: lcddefault


### PR DESCRIPTION
Added font hinting for improved readability.
This standard configuration works well for the majority of display setups.

The change I did to **x11-common** should be enough to make fonts hinting working, even if this method is often used only for applications without _fontconfig_ support.
The _fontconfig_ method get the configuration from **/etc/fonts/local.conf**, but I didn't add this file in the commit because I can't get git to work in linux and even in windows it causes some errors.

This is the configuration for **/etc/fonts/local.conf** if you want to add it too:

``` xml
<?xml version='1.0'?>
<!DOCTYPE fontconfig SYSTEM 'fonts.dtd'>
<fontconfig>
    <match target="font">

<!-- Font rasterization converts vector font data to bitmap data so that it
     can be displayed. The result can appear jagged due to aliasing.
     Anti-aliasing increases the apparent resolution of font edges. -->
        <edit mode="assign" name="antialias">
            <bool>true</bool>
        </edit>

<!-- Using normal hinting, TrueType hinting instructions in the font are
     interpreted by freetype's Byte-Code Interpreter. This works best for
     fonts with good hinting instructions. -->
        <edit mode="assign" name="hinting">
            <bool>true</bool>
        </edit>

<!-- Auto-discovery for hinting. This looks worse than normal hinting for
     fonts with good instructions, but better for those with poor or no
     instructions. The autohinter and subpixel rendering are not designed
     to work together and should not be used in combination. -->
        <edit mode="assign" name="autohint">
            <bool>false</bool>
        </edit>

<!-- Hint style is the amount of influence the hinting mode has. Hinting
     can be set to: "hintfull", "hintmedium", "hintslight" and "hintnone".
     With BCI hinting, "hintfull" should work best for most fonts.
     With the autohinter, "hintslight" is recommended. -->
        <edit mode="assign" name="hintstyle">
            <const>hintslight</const>
        </edit>

<!-- Subpixel rendering effectively triples the horizontal (or vertical)
     resolution for fonts by making use of subpixels. The autohinter and
     subpixel rendering are not designed to work together and should not
     be used in combination. Most monitors manufactured today use the
     Red, Green, Blue (RGB) specification. Fontconfig will need to know
     your monitor type to be able to display your fonts correctly.
     Values are "rgb" (most common), "bgr", "vrgb" (vertical), "vbgr",
     "unknown" or "none". -->
        <edit mode="assign" name="rgba">
            <const>rgb</const>
        </edit>

<!-- When using subpixel rendering, you should enable the LCD filter,
     which is designed to reduce colour fringing. The "lcddefault" filter
     will work for most users. Other filters are available that can be
     used in special situations: "lcdlight"; a lighter filter ideal for
     fonts that look too bold or fuzzy; "lcdlegacy", the original Cairo
     filter; "lcdnone" to disable it entirely. -->
        <edit mode="assign" name="lcdfilter">
            <const>lcddefault</const>
        </edit>

    </match>
</fontconfig>
```

I usually use both configuration.
