### PR TITLE
prefs= API to do Firefox overrides, closes #147

### DIFF
--- a/etc/webc/live-config.sh
+++ b/etc/webc/live-config.sh
@@ -149,6 +149,12 @@ for x in $( cmdline ); do
 			fi
 		;;
 
+	prefs=*)
+		prefs="$( /bin/busybox httpd -d ${x#prefs=} )"
+		wget --timeout=5 "${prefs}" -O /opt/firefox/defaults/preferences/prefs.js &&
+		logs "Set prefs: $(cat /opt/firefox/defaults/preferences/prefs.js)"
+		;;
+
 	iptables=*)
 		options=$( /bin/busybox httpd -d ${x#iptables=} )
 


### PR DESCRIPTION
Could you please sanity check this @matthijskooijman @patrickhaller ? It's a quick fix, though I do want to double prefs= is a sensible name for example.
