### PR TITLE
New xorg= API, closes #159

### DIFF
--- a/etc/webc/live-config.sh
+++ b/etc/webc/live-config.sh
@@ -161,6 +161,12 @@ for x in $( cmdline ); do
 		logs "Set prefs: $(cat /opt/firefox/defaults/preferences/prefs.js)"
 		;;
 
+	xorg=*) # https://github.com/Webconverger/webc/issues/159
+		xorg="$( /bin/busybox httpd -d ${x#xorg=} )"
+		wget -P /etc/X11/xorg.conf.d/ "${xorg}" &&
+		logs "Set Xorg: $(cat /etc/X11/xorg.conf.d/*)"
+		;;
+
 	iptables=*)
 		options=$( /bin/busybox httpd -d ${x#iptables=} )
 


### PR DESCRIPTION
Please use the runtime xrandr= API option preferably
